### PR TITLE
Require non-broken version of dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,7 +6,7 @@ on 'test' => sub {
     requires 'Test::More', '0.98';
     requires 'Test::RedisServer';
     requires 'Test::MockTime';
-    requires 'Time::Strptime';
+    requires 'Time::Strptime', '1.03';
     requires 'Redis';
 };
 


### PR DESCRIPTION
Time:Strptime prior to v 1.03 had a bug causing build test failures.

(not sure how but somehow our cpanm pulled Time::Strptime 1.02 when installing Resque::Plugin::Delay today.)